### PR TITLE
run all run jobs even with failures

### DIFF
--- a/.github/workflows/test_bioimageio_resources.yaml
+++ b/.github/workflows/test_bioimageio_resources.yaml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     strategy:
+      fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.version_matrix) }}
 
     steps:


### PR DESCRIPTION
not failing fast here and knowing which of the environments fail can simplify finding the error.