### PR TITLE
Added contact info for BMZ

### DIFF
--- a/collection.yaml
+++ b/collection.yaml
@@ -47,7 +47,7 @@ config:  # todo: clean up config (which of these fields are still used?)
       github: akreshuk
       affiliation:
         - name: EMBL
-					url: https://www.embl.org
+	  url: https://www.embl.org
 
 collection:
   - id: ilastik

--- a/collection.yaml
+++ b/collection.yaml
@@ -47,7 +47,7 @@ config:  # todo: clean up config (which of these fields are still used?)
       github: akreshuk
       affiliation:
         - name: EMBL
-	  url: https://www.embl.org
+          url: https://www.embl.org
 
 collection:
   - id: ilastik

--- a/collection.yaml
+++ b/collection.yaml
@@ -40,6 +40,14 @@ config:  # todo: clean up config (which of these fields are still used?)
     - application
   default_type: model
   url_root: https://raw.githubusercontent.com/ilastik/bioimage-io-models/main
+  docs: https://www.ilastik.org/documentation/index.html
+  contact:
+    - name: Anna Kreshuk
+      email: anna.kreshuk@embl.de
+      github: akreshuk
+      affiliation:
+        - name: EMBL
+					url: https://www.embl.org
 
 collection:
   - id: ilastik


### PR DESCRIPTION
Due to changes on the available documentation for the BioImage Model Zoo (bioimage.io) regarding the Community Partners, new contact info for Ilastik needed to be added to the manifest.