### PR TITLE
remove software tag from ilastik

### DIFF
--- a/collection.yaml
+++ b/collection.yaml
@@ -29,7 +29,6 @@ config:  # todo: clean up config (which of these fields are still used?)
   name: ilastik
   tags:
     - ilastik
-    - software
   logo: https://raw.githubusercontent.com/ilastik/bioimage-io-resources/main/image/ilastik-fist-icon.png
   icon: https://raw.githubusercontent.com/ilastik/bioimage-io-resources/main/image/ilastik-fist-icon.png
   splash_title: ilastik


### PR DESCRIPTION
it seems like clicking the partner logo will add both to the search, and thus, no models show up, which is not be the case for other partners

<img width="1243" alt="image" src="https://github.com/ilastik/bioimage-io-resources/assets/24434157/699c2806-9c32-4f67-bb53-c0c78033435d">
